### PR TITLE
Improve EEex detection

### DIFF
--- a/infinity_ui/content/UI.MENU
+++ b/infinity_ui/content/UI.MENU
@@ -11967,7 +11967,7 @@ menu
 		--	B3Scale_SetWidth(rgSetUIZoomWidth())
 		--end
 		
-		if EEex_Active then
+		if EEex_Active and EEex_Modules['B3Scale'] then
 			B3Scale_SetPercentage(RgSettingEEexZoomUI/10)
 		end
 		
@@ -38661,7 +38661,7 @@ menu
 	--}
 	text
 	{
-		enabled "EEex_Active"
+		enabled "EEex_Active and EEex_Modules['B3Scale']"
 		area		402 560 200 47
 		--area		852 329 200 47
 		text "EEex UI Zoom"
@@ -38674,7 +38674,7 @@ menu
 	}
 	slider
 	{
-		enabled "EEex_Active"
+		enabled "EEex_Active and EEex_Modules['B3Scale']"
 		area 614 560 200 47
 		--area 1066 329 200 47
 		position "RgSettingEEexZoomUI"
@@ -38695,7 +38695,7 @@ menu
 	}
 	text
 	{
-		enabled "EEex_Active"
+		enabled "EEex_Active and EEex_Modules['B3Scale']"
 		area		614 607 200 47
 		--area		1066 376 200 47
 		text lua "RgSettingEEexZoomUI*10 .. '%'"

--- a/infinity_ui/infinity_ui.tp2
+++ b/infinity_ui/infinity_ui.tp2
@@ -18,6 +18,12 @@ COPY ~infinity_ui/content~ ~override~
 
 COPY ~infinity_ui/language~ ~override~
 
+// Try to enable EEex's B3Scale module
+ACTION_IF MOD_IS_INSTALLED ~EEex.tp2~ ~0~ AND FILE_EXISTS ~override/EEex_Modules.lua~ BEGIN
+	COPY ~override/EEex_Modules.lua~ ~override~
+		REPLACE_TEXTUALLY ~^\([ %TAB%]+\["B3Scale"\][ %TAB%]+=[ %TAB%]+\)false~ ~\1true~
+	BUT_ONLY
+END
 
 
 /////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- Main component now attempts to enable EEex's B3Scale module, (if EEex is already installed).
- 'START' menu no longer breaks if EEex is installed but B3Scale module is disabled.
- "EEex UI Zoom" will only show if B3Scale module is enabled.