### PR TITLE
fix: correct x64 CRE item pointer reads; avoid freeing IDS resources

### DIFF
--- a/infinity_ui/content-eeex/my_CRE.lua
+++ b/infinity_ui/content-eeex/my_CRE.lua
@@ -23,7 +23,7 @@ function Sprite_HasItem(sprite, itm_resref)
 	local base = EEex_UDToPtr(sprite.m_equipment.m_items)
 	for i=SLOT_AMULET,SLOT_WEAPON_4 do
 		local address = base + i*8 -- *8 because x64
-		local item = EEex_Read32(address)
+		local item = EEex_Read64(address)
 		if (item ~= 0) then
 			local resref = EEex_ReadLString(item + 0x08 + 0x08, 8)
 			if resref:upper() == itm_resref then
@@ -41,7 +41,7 @@ function Sprite_HasItem_InSlot(sprite, itm_resref, slots)
 	for s=1,#slots do
 		local i =slots[s]
 		local address = base + i*8 -- *8 because x64
-		local item = EEex_Read32(address)
+		local item = EEex_Read64(address)
 		if (item ~= 0) then
 			local resref = EEex_ReadLString(item + 0x08 + 0x08, 8)
 			if resref:upper() == itm_resref then return true end
@@ -59,7 +59,7 @@ local items = {}
 for k,v in pairs(SLOTS) do
 	local i=v.id
 	local address = base + i*8 -- *8 because x64
-	local item = EEex_Read32(address)
+	local item = EEex_Read64(address)
 	if (item ~= 0) then
 		local resref = EEex_ReadLString(item + 0x08 + 0x08, 8)
 		if resref then resref = resref:upper() end

--- a/infinity_ui/content-eeex/my__RDR.lua
+++ b/infinity_ui/content-eeex/my__RDR.lua
@@ -81,13 +81,13 @@ function my_screen_radar_Inspect_sprite(sprite_row)
 	local raceIDS = EEex_Resource_LoadIDS("RACE")
 	local race_id = sprite.m_liveTypeAI.m_Race
 	local race = My_Ternary(raceIDS:hasID(race_id), raceIDS:getLine(race_id), race_id)
-	raceIDS:free()
+	-- raceIDS:free()
 
 	-- class // TODO: SHOULD BE A BETTER WAY WITH EEEX DOC, too lazy at the moment
 	local classIDS = EEex_Resource_LoadIDS("CLASS")
 	local class_id = sprite.m_liveTypeAI.m_Class
 	local class = My_Ternary(classIDS:hasID(class_id), classIDS:getLine(class_id), class_id)
-	classIDS:free()
+	-- classIDS:free()
 	-- allegiance
 	local allegiance = my_colored_allegiance(sprite.m_liveTypeAI.m_EnemyAlly)
 	result = result .. alignment .. " " .. race .. " " .. class .. " // " .. allegiance .. "\n"


### PR DESCRIPTION
- Switch equipment slot item reads from EEex_Read32 to EEex_Read64 for x64 pointer correctness.
- Remove manual IDS freeing: instances returned by EEex_Resource_LoadIDS() are garbage-collected.